### PR TITLE
Sec/stop disclosing secrets on build

### DIFF
--- a/vars/helpers.groovy
+++ b/vars/helpers.groovy
@@ -17,7 +17,7 @@ def getTagName() {
 }
 
 def ECRLogin(){
-    sh "eval \$(aws ecr get-login --no-include-email --region eu-central-1)"
+    sh "eval \$(aws ecr get-login --no-include-email --region eu-central-1) 2>&1 1>/dev/null"
 }
 
 def retagAndPushImage(String project, String branch_name, String tag){

--- a/vars/helpers.groovy
+++ b/vars/helpers.groovy
@@ -17,7 +17,7 @@ def getTagName() {
 }
 
 def ECRLogin(){
-    sh "eval \$(aws ecr get-login --no-include-email --region eu-central-1) 2>&1 1>/dev/null"
+    sh "set +x; eval \$(aws ecr get-login --no-include-email --region eu-central-1) 2>&1 1>/dev/null"
 }
 
 def retagAndPushImage(String project, String branch_name, String tag){

--- a/vars/helpers.groovy
+++ b/vars/helpers.groovy
@@ -17,7 +17,7 @@ def getTagName() {
 }
 
 def ECRLogin(){
-    sh "set +x; eval \$(aws ecr get-login --no-include-email --region eu-central-1) 2>&1 1>/dev/null"
+    sh "set +x; eval \$(aws ecr get-login --no-include-email --region eu-central-1) >/dev/null 2>&1"
 }
 
 def retagAndPushImage(String project, String branch_name, String tag){


### PR DESCRIPTION
I assume that `set -x` is set by jenkins when it executes a `sh "command"`, if it is set only once at the beginning of the buil, then we want to re-add the stdout flag with `; set -x` after the ecr login command.